### PR TITLE
Update component if the source changed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ class Img extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps.config.innerWidth !== this.props.config.innerWidth)
+    if (prevProps.config.innerWidth !== this.props.config.innerWidth || this.props.src !== prevProps.src)
       this.processImage();
   }
 


### PR DESCRIPTION
We have encountered a bug where once we swap the source of an image (hover over or click) the Cloudimage Img tag does not update in react.
This line here:
https://github.com/scaleflex/react-cloudimage-responsive/blob/c07eb0556230c0cb78650ae32f456336a0b08639/src/index.js#L37
should be extended with the extra check proposed in this pull request.

Quick turnaround with a new tag would be appreciated.