### PR TITLE
Prevent the lazyLoading property from being spread onto the img tag.

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-export const getFilteredProps = ({ config = {}, alt = '', className = '', src, sizes, width, height, params, ...otherProps }) => ({
+export const getFilteredProps = ({ config = {}, alt = '', className = '', src, sizes, width, height, params, lazyLoading, ...otherProps }) => ({
   alt,
   className,
   imgNodeWidth: width,


### PR DESCRIPTION
Fixes the warning: "Warning: React does not recognize the `lazyLoading` prop on a DOM element."